### PR TITLE
Add riuso key

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -29,6 +29,9 @@ localisation:
     - it
     - en
 it:
+  countryExtensionVersion: "0.2"
+  riuso:
+    codiceIPA: c_d969
   piattaforme:
     spid: true
 description:


### PR DESCRIPTION
Buongiorno @ComuneGenova @ago75,
questa PR:
* aggiunge la chiave "riuso" con il codiceIPA relativo al Comune di Genova per permettere un'adeguata indicizzazione nel catalogo.

Resto a disposizione.
Grazie